### PR TITLE
fix: change password modal does not add turnstile token

### DIFF
--- a/js/src/forum/extend/addTurnstileToChangePassword.tsx
+++ b/js/src/forum/extend/addTurnstileToChangePassword.tsx
@@ -1,0 +1,57 @@
+import app from 'flarum/forum/app';
+import { override } from 'flarum/common/extend';
+import Button from 'flarum/common/components/Button';
+import ChangePasswordModal from 'flarum/forum/components/ChangePasswordModal';
+
+import Turnstile from '../components/Turnstile';
+
+export default function addTurnstileToForgotPassword() {
+  ChangePasswordModal.prototype.__turnstileToken = null;
+
+  override(ChangePasswordModal.prototype, 'content', function (this: ChangePasswordModal, original) {
+    if (!!!app.forum.attribute('blomstra-turnstile.forgot')) return;
+
+    return (
+      <div className="Modal-body">
+        <div className="Form Form--centered">
+          <p className="helpText">{app.translator.trans('core.forum.change_password.text')}</p>
+          <div className="Form-group">
+            {Button.component(
+              {
+                className: 'Button Button--primary Button--block',
+                type: 'submit',
+                loading: this.loading,
+              },
+              app.translator.trans('core.forum.change_password.send_button')
+            )}
+          </div>
+          <Turnstile
+            action="forgot_pw"
+            onTurnstileStateChange={(token) => {
+              this.__turnstileToken = token;
+            }}
+          />
+        </div>
+      </div>
+    );
+  });
+
+  override(ChangePasswordModal.prototype, 'onsubmit', function (this: ChangePasswordModal, original, e: SubmitEvent) {
+    if (!!!app.forum.attribute('blomstra-turnstile.forgot')) return;
+
+    e.preventDefault();
+
+    this.loading = true;
+
+    app
+      .request({
+        method: 'POST',
+        url: app.forum.attribute('apiUrl') + '/forgot',
+        body: {
+          email: app.session.user!.email(),
+          turnstileToken: this.__turnstileToken,
+        },
+      })
+      .then(this.hide.bind(this), this.loaded.bind(this));
+  });
+}

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -1,11 +1,12 @@
 import app from 'flarum/forum/app';
 import addTurnstileToForgotPassword from './extend/addTurnstileToForgotPassword';
+import addTurnstileToChangePassword from './extend/addTurnstileToChangePassword';
 import addTurnstileToLogin from './extend/addTurnstileToLogin';
-
 import addTurnstileToSignUp from './extend/addTurnstileToSignUp';
 
 app.initializers.add('blomstra/turnstile', () => {
   addTurnstileToSignUp();
   addTurnstileToLogin();
   addTurnstileToForgotPassword();
+  addTurnstileToChangePassword();
 });


### PR DESCRIPTION
The change password modal uses the `forgot` password endpoint, so requiring turnstile token in that endpoint means we ought to add the token to that modal as well.